### PR TITLE
Utilize ea3-ident instead of ea3-config for datecodes

### DIFF
--- a/sdvx@asphyxia/handlers/webui.ts
+++ b/sdvx@asphyxia/handlers/webui.ts
@@ -178,8 +178,8 @@ export const copyResourcesFromGame = async (data: {}) => {
   console.log('Getting new music_db info')
   if(IO.Exists(U.GetConfig('sdvx_eg_root_dir') + "/data/others/music_db.xml")) {
     let mdb = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/data/others/music_db.xml"), "shift_jis"), false)
-    let ea3Config = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-config.xml"), "shift_jis"), false)
-    let version = ea3Config['ea3']['soft']['ext']['@content'];
+    let ea3Config = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-ident.xml"), "shift_jis"), false)
+    let version = ea3Config['ea3_conf']['soft']['ext']['@content'];
     let prevAssetMdb = []
     if(IO.Exists('webui/asset/json/music_db.json')) {
       prevAssetMdb = JSON.parse(U.DecodeString(await IO.ReadFile('webui/asset/json/music_db.json'), 'utf8'))

--- a/sdvx@asphyxia/handlers/webui.ts
+++ b/sdvx@asphyxia/handlers/webui.ts
@@ -177,9 +177,19 @@ export const copyResourcesFromGame = async (data: {}) => {
   // Get new music data from music_db.xml
   console.log('Getting new music_db info')
   if(IO.Exists(U.GetConfig('sdvx_eg_root_dir') + "/data/others/music_db.xml")) {
+    let ea3Config = []
+    let version = ''
     let mdb = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/data/others/music_db.xml"), "shift_jis"), false)
-    let ea3Config = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-ident.xml"), "shift_jis"), false)
-    let version = ea3Config['ea3_conf']['soft']['ext']['@content'];
+
+    if(IO.Exists(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-config.xml")) {
+      console.log("Reading ea3-config.xml")
+      ea3Config = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-config.xml"), "shift_jis"), false)
+      version = ea3Config['ea3']['soft']['ext']['@content'];
+    } else if(IO.Exists(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-ident.xml")) {
+      console.log("Reading ea3-ident.xml")
+      ea3Config = U.parseXML(U.DecodeString(await IO.ReadFile(U.GetConfig('sdvx_eg_root_dir') + "/prop/ea3-ident.xml"), "shift_jis"), false)
+      version = ea3Config['ea3_conf']['soft']['ext']['@content'];
+    }
     let prevAssetMdb = []
     if(IO.Exists('webui/asset/json/music_db.json')) {
       prevAssetMdb = JSON.parse(U.DecodeString(await IO.ReadFile('webui/asset/json/music_db.json'), 'utf8'))


### PR DESCRIPTION
On some distributions, the game makes use of an ea3-ident.xml file which stores the model and datecode information. I updated the handler to utilize this, although I feel like a better option would be to check both. Open for any edits!